### PR TITLE
Chore: adds @semantic-release/npm

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -37,6 +37,7 @@
                 "changelogFile": "CHANGELOG.md"
             }
         ],
+        "@semantic-release/npm",
         "@semantic-release/github",
         [
             "@semantic-release/git", {


### PR DESCRIPTION
Adding `@semantic-release/npm` to the `.releaserc.json` file to see if that allows package.json version to update.